### PR TITLE
Documented new API username requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,14 @@ and now your light should be green! You can also reference lights by name:
     client = HueBridgeClient()
     client.set_color('Office 1', '00ff00')
 
+The first time you connect to a bridge, the username you specify (default ``bulbyappdev``) will be created on that bridge.
 
+.. code-block:: python
+
+    from bulby.client import HueBridgeClient
+    client = HueBridgeClient(username='sometestusername')
+
+Note: The Hue API requires the username to be at least 10 characters long. Attempting to create a shorter username will result in an error like: ``Exception: invalid value,  tooshort, for parameter, username``.
 
 Development
 ================

--- a/bulby/client.py
+++ b/bulby/client.py
@@ -9,7 +9,7 @@ import json
 
 class HueBridgeClient(object):
     def __init__(self, ip_address=None, port=80, scheme='http',
-                 device_type='bulby', username='bulbyapp'):
+                 device_type='bulby', username='bulbyappdev'):
         '''
         Connects to a Hue Bridge, if an ip address isn't defined it
         will use ssdp to discover the bridge on the network. If there


### PR DESCRIPTION
As of the most recent bridge software update (and perhaps earlier but I can't confirm), usernames seem to require 10 characters.

``` python
    >>> from bulby.client import HueBridgeClient
    >>> client = HueBridgeClient(username='123456789')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/private/tmp/bulby/bulby/client.py", line 44, in __init__
        self.connect()
      File "/private/tmp/bulby/bulby/client.py", line 94, in connect
        raise Exception(msg)
    Exception: invalid value,  123456789, for parameter, username

    >>> client = HueBridgeClient(username='1234567890')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/private/tmp/bulby/bulby/client.py", line 44, in __init__
        self.connect()
      File "/private/tmp/bulby/bulby/client.py", line 94, in connect
        raise Exception(msg)
    Exception: Please press the link button and try again
```

I updated the default username to `bulbyappdev` to be longer than 10 characters, and made a node in `README.rst` as a pointer to other devs.
